### PR TITLE
Fix typos

### DIFF
--- a/commands/runner.exs
+++ b/commands/runner.exs
@@ -58,7 +58,7 @@ defmodule Runner do
   # handles the `undo` message
   # pattern matches the `done` list, extracting the first command and the tail
   def handle_call(:undo, _from, state = %{done: [command = {mod, args} | t]}) do
-    # dynamically call `unexecute` on the commmand module
+    # dynamically call `unexecute` on the command module
     apply(mod, :unexecute, List.wrap(args))
 
     # update the `done` stack to the tail
@@ -72,7 +72,7 @@ defmodule Runner do
   # handles the `redo` message
   # pattern matches the `undone` list, extracting the first command and the tail
   def handle_call(:redo, _from, state = %{undone: [command = {mod, args} | t]}) do
-    # dynamically call `execute` on the commmand module
+    # dynamically call `execute` on the command module
     apply(mod, :execute, List.wrap(args))
 
     # update the `undone` stack to the tail

--- a/factory/shape_factory.exs
+++ b/factory/shape_factory.exs
@@ -11,6 +11,6 @@ defmodule ShapeFactory do
   def create(:rectangle, %{width: width, height: height}), do: {:rectangle, width, height}
   def create(:rectangle, %{x1: x1, x2: x2, y1: y1, y2: y2}), do: {:rectangle, x2 - x1, y2 - y1}
 
-  # We create rectangles when asked for a square (mathimatically wrong, but whatevs)
+  # We create rectangles when asked for a square (mathematically wrong, but whatevs)
   def create(:square, %{size: size}), do: {:rectangle, size, size}
 end


### PR DESCRIPTION
Found via `codespell .`